### PR TITLE
Add account hierarchy PCF control

### DIFF
--- a/AccountHierarchy/ControlManifest.Input.xml
+++ b/AccountHierarchy/ControlManifest.Input.xml
@@ -32,22 +32,11 @@
     -->
     <resources>
       <code path="index.ts" order="1"/>
-      <!-- UNCOMMENT TO ADD MORE RESOURCES
       <css path="css/AccountHierarchy.css" order="1" />
-      <resx path="strings/AccountHierarchy.1033.resx" version="1.0.0" />
-      -->
+      <!-- <resx path="strings/AccountHierarchy.1033.resx" version="1.0.0" /> -->
     </resources>
-    <!-- UNCOMMENT TO ENABLE THE SPECIFIED API
     <feature-usage>
-      <uses-feature name="Device.captureAudio" required="true" />
-      <uses-feature name="Device.captureImage" required="true" />
-      <uses-feature name="Device.captureVideo" required="true" />
-      <uses-feature name="Device.getBarcodeValue" required="true" />
-      <uses-feature name="Device.getCurrentPosition" required="true" />
-      <uses-feature name="Device.pickFile" required="true" />
-      <uses-feature name="Utility" required="true" />
       <uses-feature name="WebAPI" required="true" />
     </feature-usage>
-    -->
   </control>
 </manifest>

--- a/AccountHierarchy/index.ts
+++ b/AccountHierarchy/index.ts
@@ -1,9 +1,22 @@
 import { IInputs, IOutputs } from "./generated/ManifestTypes";
 
+interface AccountEntity {
+    accountid: string;
+    name: string;
+    accountnumber: string;
+    rpc_accounttype?: number;
+    "rpc_accounttype@OData.Community.Display.V1.FormattedValue"?: string;
+    _msdyn_partyid_value?: string;
+    _parentaccountid_value?: string;
+}
+
 export class AccountHierarchy implements ComponentFramework.StandardControl<IInputs, IOutputs> {
-    /**
-     * Empty constructor.
-     */
+    private _context: ComponentFramework.Context<IInputs> | undefined;
+    private _container: HTMLDivElement | undefined;
+    private _notifyOutputChanged: (() => void) | undefined;
+    private _accounts: Record<string, AccountEntity> = {};
+    private _tooltip: HTMLDivElement | undefined;
+
     constructor() {
         // Empty
     }
@@ -22,7 +35,12 @@ export class AccountHierarchy implements ComponentFramework.StandardControl<IInp
         state: ComponentFramework.Dictionary,
         container: HTMLDivElement
     ): void {
-        // Add control initialization code
+        this._context = context;
+        this._notifyOutputChanged = notifyOutputChanged;
+        this._container = container;
+        container.classList.add("accountHierarchyContainer");
+
+        this.loadAccounts();
     }
 
 
@@ -31,7 +49,7 @@ export class AccountHierarchy implements ComponentFramework.StandardControl<IInp
      * @param context The entire property bag available to control via Context Object; It contains values as set up by the customizer mapped to names defined in the manifest, as well as utility functions
      */
     public updateView(context: ComponentFramework.Context<IInputs>): void {
-        // Add code to update control view
+        this._context = context;
     }
 
     /**
@@ -48,5 +66,102 @@ export class AccountHierarchy implements ComponentFramework.StandardControl<IInp
      */
     public destroy(): void {
         // Add code to cleanup control if necessary
+    }
+
+    private loadAccounts(): void {
+        if (!this._context) return;
+        this._context.webAPI
+            .retrieveMultipleRecords(
+                "account",
+                "?$select=accountid,name,accountnumber,rpc_accounttype,_msdyn_partyid_value,_parentaccountid_value&$top=50"
+            )
+            .then((result) => {
+                this._accounts = {};
+                result.entities.forEach((e: any) => {
+                    this._accounts[e.accountid] = e as AccountEntity;
+                });
+                this.renderHierarchy();
+            });
+    }
+
+    private renderHierarchy(): void {
+        if (!this._container) return;
+        this._container.innerHTML = "";
+        const roots = Object.values(this._accounts).filter(
+            (a) => !a._parentaccountid_value
+        );
+        roots.forEach((r) => {
+            const node = this.createNode(r);
+            this._container!.appendChild(node);
+        });
+    }
+
+    private createNode(account: AccountEntity): HTMLElement {
+        const wrapper = document.createElement("div");
+        wrapper.classList.add("accountNode");
+        wrapper.textContent = `${account.name} (${account.accountnumber}) - ${this.getAccountTypeLabel(account)}`;
+        wrapper.onmouseenter = () => this.showAddress(account, wrapper);
+        wrapper.onmouseleave = () => this.hideTooltip();
+
+        const children = Object.values(this._accounts).filter(
+            (a) => a._parentaccountid_value === account.accountid
+        );
+        if (children.length) {
+            const container = document.createElement("div");
+            container.classList.add("children");
+            children.forEach((c) => container.appendChild(this.createNode(c)));
+            wrapper.appendChild(container);
+        }
+        return wrapper;
+    }
+
+    private showAddress(account: AccountEntity, el: HTMLElement): void {
+        if (!this._context) return;
+        if (!this._tooltip) {
+            this._tooltip = document.createElement("div");
+            this._tooltip.classList.add("addressTooltip");
+            this._container?.appendChild(this._tooltip);
+        }
+        this._tooltip.style.display = "block";
+        this._tooltip.innerHTML = "Loading...";
+        this.positionTooltip(el);
+
+        if (!account._msdyn_partyid_value) {
+            this._tooltip.innerHTML = "No party";
+            return;
+        }
+
+        const filter = `?$select=msdyn_name,msdyn_street,msdyn_city,msdyn_state,msdyn_countryregionid,msdyn_zipcode&$filter=_msdyn_party_value eq ${account._msdyn_partyid_value}`;
+        this._context.webAPI
+            .retrieveMultipleRecords("msdyn_postaladdress", filter)
+            .then((res) => {
+                if (res.entities.length) {
+                    const a = res.entities[0] as any;
+                    this._tooltip!.innerHTML = `<strong>${a.msdyn_name}</strong><br>${a.msdyn_street}<br>${a.msdyn_city}, ${a.msdyn_state}<br>${a.msdyn_countryregionid} ${a.msdyn_zipcode}`;
+                } else {
+                    this._tooltip!.innerHTML = "No address found";
+                }
+            });
+    }
+
+    private positionTooltip(target: HTMLElement): void {
+        if (!this._tooltip) return;
+        const rect = target.getBoundingClientRect();
+        this._tooltip.style.top = `${rect.bottom + 5}px`;
+        this._tooltip.style.left = `${rect.left}px`;
+    }
+
+    private hideTooltip(): void {
+        if (this._tooltip) {
+            this._tooltip.style.display = "none";
+        }
+    }
+
+    private getAccountTypeLabel(account: AccountEntity): string {
+        return (
+            account[
+                "rpc_accounttype@OData.Community.Display.V1.FormattedValue"
+            ] || ""
+        );
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # AccountHierarchy
+
+This PCF control displays a hierarchy of accounts. Each node shows the account name, number and account type. When hovering over a node, the related postal address is retrieved and displayed as a tooltip.
+
+### Features
+
+- Fetches account records using the Web API and builds a tree based on the parent account relationship.
+- Shows the label of the `rpc_accounttype` option set.
+- On mouse hover the control retrieves the party and postal address to show `msdyn_name`, `msdyn_street`, `msdyn_city`, `msdyn_state`, `msdyn_countryregionid` and `msdyn_zipcode`.
+- UI elements use `rgb(40, 116, 252)` for styling.
+
+### Development
+
+Install dependencies and build:
+
+```bash
+npm install
+npm run build
+```

--- a/css/AccountHierarchy.css
+++ b/css/AccountHierarchy.css
@@ -1,0 +1,24 @@
+.accountHierarchyContainer {
+    font-family: Arial, sans-serif;
+    color: rgb(40, 116, 252);
+}
+
+.accountNode {
+    padding: 4px;
+    margin-left: 10px;
+    cursor: pointer;
+}
+
+.addressTooltip {
+    position: fixed;
+    background: white;
+    border: 1px solid rgb(40, 116, 252);
+    padding: 4px;
+    z-index: 1000;
+    display: none;
+    color: black;
+}
+
+.children {
+    margin-left: 15px;
+}


### PR DESCRIPTION
## Summary
- implement basic hierarchy control for accounts
- add CSS styling in `rgb(40,116,252)`
- enable WebAPI usage in manifest
- document features and development steps

## Testing
- `npm run lint` *(fails: pcf-scripts not found)*
- `npm run build` *(fails: pcf-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ce305e96c832ca8ec82dd89910526